### PR TITLE
Improve UX for new 'local' users without assigned locations

### DIFF
--- a/screens/LocalDashboard.js
+++ b/screens/LocalDashboard.js
@@ -90,7 +90,7 @@ const LocalDashboard = ({ navigation }) => {
                 data={assignedLocales}
                 renderItem={renderItem}
                 keyExtractor={item => item.id}
-                ListEmptyComponent={<Text style={styles.emptyText}>No tienes locales asignados.</Text>}
+                ListEmptyComponent={<Text style={styles.emptyText}>Aún no tienes locales asignados. Por favor, contacta a un administrador para que te asigne uno y puedas comenzar a usar la aplicación.</Text>}
             />
         </View>
     );


### PR DESCRIPTION
The previous message "No tienes locales asignados" was unhelpful and provided no guidance for new users on how to proceed.

This change replaces the message with a more informative one that instructs the user to contact an administrator to get a location assigned. This improves the user experience by providing clear next steps.